### PR TITLE
No longer exposes Nom details, adds FromStr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["iso8601", "duration", "parser"]
 travis-ci = { repository = "PoiScript/iso8601-duration" }
 
 [dependencies]
-nom = "5.0.1"
+nom = "^6"

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str::FromStr;
 use std::time::Duration as StdDuration;
 
@@ -79,6 +80,12 @@ impl DurationParseError {
 impl From<Err<Error<&str>>> for DurationParseError {
     fn from(err: Err<Error<&str>>) -> Self {
         DurationParseError(err.to_string())
+    }
+}
+
+impl fmt::Display for DurationParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -50,13 +50,35 @@ impl Duration {
         )
     }
 
-    pub fn parse(input: &str) -> Result<Duration, Err<Error<&str>>> {
+    pub fn parse(input: &str) -> Result<Duration, DurationParseError> {
         let (_, duration) = all_consuming(preceded(
             tag("P"),
             alt((parse_week_format, parse_basic_format)),
         ))(input)?;
 
         Ok(duration)
+    }
+}
+
+impl FromStr for Duration {
+    type Err = DurationParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Duration::parse(s).map_err(DurationParseError::from)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurationParseError(String);
+
+impl DurationParseError {
+    pub fn new<S: Into<String>>(s: S) -> DurationParseError {
+        DurationParseError(s.into())
+    }
+}
+
+impl From<Err<Error<&str>>> for DurationParseError {
+    fn from(err: Err<Error<&str>>) -> Self {
+        DurationParseError(err.to_string())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use iso8601_duration::Duration;
-//! use nom::{error::ErrorKind, error::Error};
+//! use iso8601_duration::{ Duration, DurationParseError };
 //! use std::time::Duration as StdDuration;
 //!  assert_eq!(
 //!      Duration::parse("P23DT23H"),
@@ -46,22 +45,22 @@
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("PT"),
-//!      Err(nom::Err::Error(Error { input: "", code: ErrorKind::Verify }))
+//!      Err(DurationParseError::new("Parsing Error: Error { input: \"\", code: Verify }"))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P12WT12H30M5S"),
-//!      Err(nom::Err::Error(Error { input: "T12H30M5S", code: ErrorKind::Eof }))
+//!      Err(DurationParseError::new("Parsing Error: Error { input: \"T12H30M5S\", code: Eof }"))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5S0.5M"),
-//!      Err(nom::Err::Error(Error { input: "0.5S0.5M", code: ErrorKind::Verify }))
+//!      Err(DurationParseError::new("Parsing Error: Error { input: \"0.5S0.5M\", code: Verify }"))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5A"),
-//!      Err(nom::Err::Error(Error { input: "0.5A", code: ErrorKind::Verify }))
+//!      Err(DurationParseError::new("Parsing Error: Error { input: \"0.5A\", code: Verify }"))
 //!  );
 //! ```
 
 mod duration;
 
-pub use crate::duration::Duration;
+pub use crate::duration::{Duration, DurationParseError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! ```rust
 //! use iso8601_duration::Duration;
-//! use nom::{error::ErrorKind, Err};
-//!
+//! use nom::{error::ErrorKind, error::Error};
+//! use std::time::Duration as StdDuration;
 //!  assert_eq!(
 //!      Duration::parse("P23DT23H"),
 //!      Ok(Duration::new(0., 0., 23., 23., 0., 0.))
@@ -32,22 +32,33 @@
 //!      Duration::parse("P12W"),
 //!      Ok(Duration::new(0., 0., 84., 0., 0., 0.))
 //!  );
-//!
+//!  assert_eq!(
+//!      Duration::parse("PT30M5S").unwrap().to_std(),
+//!      StdDuration::new(30 * 60 + 5, 0)
+//!  );
+//!  assert_eq!(
+//!      Duration::parse("PT5H5M5S").unwrap().to_std(),
+//!      StdDuration::new(5 * 3600 + 5 * 60 + 5, 0)
+//!  );
+//!  assert_eq!(
+//!      Duration::parse("PT5H5M5.555S").unwrap().to_std(),
+//!      StdDuration::new(5 * 3600 + 5 * 60 + 5, 555_000_000)
+//!  );
 //!  assert_eq!(
 //!      Duration::parse("PT"),
-//!      Err(Err::Error(("", ErrorKind::Verify)))
+//!      Err(nom::Err::Error(Error { input: "", code: ErrorKind::Verify }))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P12WT12H30M5S"),
-//!      Err(Err::Error(("T12H30M5S", ErrorKind::Eof)))
+//!      Err(nom::Err::Error(Error { input: "T12H30M5S", code: ErrorKind::Eof }))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5S0.5M"),
-//!      Err(Err::Error(("0.5S0.5M", ErrorKind::Verify)))
+//!      Err(nom::Err::Error(Error { input: "0.5S0.5M", code: ErrorKind::Verify }))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5A"),
-//!      Err(Err::Error(("0.5A", ErrorKind::Verify)))
+//!      Err(nom::Err::Error(Error { input: "0.5A", code: ErrorKind::Verify }))
 //!  );
 //! ```
 


### PR DESCRIPTION
Adds a FromStr implementation to make it easier to use with 3rd party parsers (like Clap and Serde) 

No longer exposes the Nom Errors from outside the crate.
Introduces a new custom error type