### PR TITLE
Updated nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["iso8601", "duration", "parser"]
 travis-ci = { repository = "PoiScript/iso8601-duration" }
 
 [dependencies]
-nom = "5.0.1"
+nom = "7.1.3"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ use nom::{error::ErrorKind, Err};
 
 ### Unreleased
 
-- Breaking: Updated nom to version 7
+- Breaking: Updated nom to version 7 (https://github.com/PoiScript/iso8601-duration/pull/13)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ use nom::{error::ErrorKind, Err};
  );
 ```
 
+## Changelog
+
+### Unreleased
+
+- Breaking: Updated nom to version 7
+
 ## License
 
 MIT

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -45,7 +45,7 @@ impl Duration {
         )
     }
 
-    pub fn parse(input: &str) -> Result<Duration, Err<(&str, ErrorKind)>> {
+    pub fn parse(input: &str) -> Result<Duration, Err<nom::error::Error<&str>>> {
         let (_, duration) = all_consuming(preceded(
             tag("P"),
             alt((parse_week_format, parse_basic_format)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,19 +35,19 @@
 //!
 //!  assert_eq!(
 //!      Duration::parse("PT"),
-//!      Err(Err::Error(("", ErrorKind::Verify)))
+//!      Err(Err::Error(nom::error::Error::new("", ErrorKind::Verify)))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P12WT12H30M5S"),
-//!      Err(Err::Error(("T12H30M5S", ErrorKind::Eof)))
+//!      Err(Err::Error(nom::error::Error::new("T12H30M5S", ErrorKind::Eof)))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5S0.5M"),
-//!      Err(Err::Error(("0.5S0.5M", ErrorKind::Verify)))
+//!      Err(Err::Error(nom::error::Error::new("0.5S0.5M", ErrorKind::Verify)))
 //!  );
 //!  assert_eq!(
 //!      Duration::parse("P0.5A"),
-//!      Err(Err::Error(("0.5A", ErrorKind::Verify)))
+//!      Err(Err::Error(nom::error::Error::new("0.5A", ErrorKind::Verify)))
 //!  );
 //! ```
 


### PR DESCRIPTION
From the new 1.68 compiler version and onwards we get a warning that nom 5 will stop compiling in the future.
This PR updates the codebase to nom 7.

This is a breaking change.

I took the freedom to add a changelog to the readme